### PR TITLE
fix(rogue): pace FPS through the engine's vsync mode

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -67,7 +67,7 @@ IncludeCategories:
     Priority: 30
     SortPriority: 30
   # Other Windows / system headers
-  - Regex: '^<(winternl|DbgHelp|guiddef|dxgi)\.h>'
+  - Regex: '^<(winternl|DbgHelp|guiddef|timeapi|dxgi)\.h>'
     Priority: 30
     SortPriority: 31
   # Test frameworks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(AC.PatchFix.Core OBJECT
     src/vmp/integrity_bypass.cpp
     src/vmp/pe_sections.cpp
     src/win32/pe.cpp
+    src/win32/timer_resolution.cpp
     src/diagnostics/stack_walker.cpp
     src/diagnostics/crash_report.cpp
     src/diagnostics/minidump.cpp
@@ -79,6 +80,7 @@ target_link_libraries(AC.PatchFix.Core PUBLIC
     HookingPatterns
     mINI
     spdlog::spdlog_header_only
+    winmm
 )
 target_compile_definitions(AC.PatchFix.Core PUBLIC ${SHARED_COMPILE_DEFINITIONS})
 target_compile_options(AC.PatchFix.Core PUBLIC ${SHARED_COMPILE_OPTIONS})

--- a/config/AC.Rogue.PatchFix.ini
+++ b/config/AC.Rogue.PatchFix.ini
@@ -41,6 +41,8 @@ Multiplier=1.0
 
 ; Target FPS limit. 0 = uncapped (removes frame limiter entirely).
 ; Any positive value = cap to that FPS (e.g. 60, 120, 144).
+; The plugin raises the process timer resolution to 1 ms while loaded, which
+; the game itself never does — without it nothing above ~64 FPS is reachable.
 ; Default: 0
 Target=0
 

--- a/config/AC.Rogue.PatchFix.ini
+++ b/config/AC.Rogue.PatchFix.ini
@@ -41,8 +41,9 @@ Multiplier=1.0
 
 ; Target FPS limit. 0 = uncapped (removes frame limiter entirely).
 ; Any positive value = cap to that FPS (e.g. 60, 120, 144).
-; The plugin raises the process timer resolution to 1 ms while loaded, which
-; the game itself never does — without it nothing above ~64 FPS is reachable.
+; When a cap is set the plugin raises the process timer resolution to 1 ms, so
+; the game's own frame wait can pace accurately; the game itself never does
+; this. Uncapped there is no wait at all, so the resolution is left alone.
 ; Default: 0
 Target=0
 

--- a/games/rogue/hooks/fps_unlock.cpp
+++ b/games/rogue/hooks/fps_unlock.cpp
@@ -4,8 +4,6 @@
 
 #include <algorithm>
 
-#include <Windows.h>
-
 #include "core/logger.hpp" // IWYU pragma: keep
 
 #include "core/mem/write.hpp"
@@ -21,23 +19,12 @@ namespace hooks {
 
         games::rogue::FrameTiming *g_frame_timing = nullptr;
 
-        // The vsync-mode deadline period in milliseconds, read by the mulss inside
+        // The frame deadline period in milliseconds, read by the mulss inside
         // UpdateFrameTiming. Sole reference in the binary, so it is ours to retune.
-        std::uintptr_t g_cap_period      = 0;
-        float          g_cap_period_orig = 0.0F;
+        std::uintptr_t g_cap_period = 0;
 
         constexpr float         k_min_fps    = 1.0F;
-        constexpr std::uint32_t k_mode_fixed = 0;
         constexpr std::uint32_t k_mode_vsync = 2;
-
-        void prime_timestamps() {
-            LARGE_INTEGER qpc;
-            QueryPerformanceCounter(&qpc);
-            auto now                      = static_cast<std::uint64_t>(qpc.QuadPart);
-            g_frame_timing->current_time  = now;
-            g_frame_timing->previous_time = now;
-            g_frame_timing->target_time   = 0;
-        }
 
         void apply_fps_patch(float target) {
             if (g_frame_timing == nullptr || g_cap_period == 0) {
@@ -46,29 +33,27 @@ namespace hooks {
 
             target = std::max(target, 0.0F);
 
-            if (target < k_min_fps) {
-                // Vsync mode measures each frame individually and keeps the engine's
-                // own 1/15 s clamp on the delta. Zeroing its period leaves the frame
-                // deadline at "now", so the wait loop never runs.
-                if (!mem::write<float>(g_cap_period, 0.0F)) {
-                    log::get()->error("FPSUnlockHook: failed to zero cap period");
-                    return;
-                }
-                g_frame_timing->timing_mode = k_mode_vsync;
-                prime_timestamps();
-                log::get()->trace("FPSUnlockHook: uncapped (mode=vsync, period=0.0)");
+            // In vsync mode the deadline is current_time + trunc(ticks_per_ms *
+            // period), so the period alone paces the game and the engine keeps its
+            // own measured delta. A period of zero leaves the deadline at "now",
+            // which the wait loop never has to wait for.
+            float period = target < k_min_fps ? 0.0F : 1000.0F / target;
+
+            if (!mem::write<float>(g_cap_period, period)) {
+                log::get()->error("FPSUnlockHook: failed to write cap period");
+                return;
+            }
+
+            // The pending deadline was computed from the previous period and would
+            // stall the wait loop once before the next frame recomputes it.
+            g_frame_timing->target_time = 0;
+
+            if (period == 0.0F) {
+                log::get()->trace("FPSUnlockHook: uncapped (period=0.0)");
             } else {
-                if (!mem::write<float>(g_cap_period, g_cap_period_orig)) {
-                    log::get()->error("FPSUnlockHook: failed to restore cap period");
-                    return;
-                }
-                g_frame_timing->timing_mode = k_mode_fixed;
-                g_frame_timing->fixed_rate  = target;
-                prime_timestamps();
-                log::get()->trace("FPSUnlockHook: capped to {:.1f} FPS (mode=fixed, "
-                                  "fixed_rate={:.4f})",
+                log::get()->trace("FPSUnlockHook: capped to {:.1f} FPS (period={:.4f} ms)",
                                   target,
-                                  target);
+                                  period);
             }
         }
     } // namespace
@@ -97,11 +82,18 @@ namespace hooks {
                           g_frame_timing->timing_mode,
                           g_frame_timing->fixed_rate);
 
-        g_cap_period      = mem::x64::read_rel(addrs.fps_cap_mulss.value() + 4);
-        g_cap_period_orig = mem::read<float>(g_cap_period);
+        // The constructor sets vsync mode and nothing in the game writes the field
+        // afterwards. Any other value means the period below paces nothing.
+        if (g_frame_timing->timing_mode != k_mode_vsync) {
+            log::get()->warn("FPSUnlockHook: unexpected timing_mode={}, expected {}",
+                             g_frame_timing->timing_mode,
+                             k_mode_vsync);
+        }
+
+        g_cap_period = mem::x64::read_rel(addrs.fps_cap_mulss.value() + 4);
         log::get()->trace("FPSUnlockHook: cap period at 0x{:X} ({:.6f} ms)",
                           g_cap_period,
-                          g_cap_period_orig);
+                          mem::read<float>(g_cap_period));
 
         // The game never raises the timer resolution, so its Sleep(1) frame wait
         // runs at the ~15.6 ms default quantum and cannot pace anything faster

--- a/games/rogue/hooks/fps_unlock.cpp
+++ b/games/rogue/hooks/fps_unlock.cpp
@@ -39,6 +39,17 @@ namespace hooks {
             // which the wait loop never has to wait for.
             float period = target < k_min_fps ? 0.0F : 1000.0F / target;
 
+            // Only the capped path sleeps. Raising the process timer resolution
+            // while uncapped changes Sleep() granularity for every other thread
+            // in the game and paces nothing.
+            if (period == 0.0F) {
+                win32::restore_timer_resolution();
+            } else if (win32::raise_timer_resolution()) {
+                log::get()->trace("FPSUnlockHook: timer resolution raised to 1 ms");
+            } else {
+                log::get()->warn("FPSUnlockHook: failed to raise timer resolution");
+            }
+
             if (!mem::write<float>(g_cap_period, period)) {
                 log::get()->error("FPSUnlockHook: failed to write cap period");
                 return;
@@ -94,15 +105,6 @@ namespace hooks {
         log::get()->trace("FPSUnlockHook: cap period at 0x{:X} ({:.6f} ms)",
                           g_cap_period,
                           mem::read<float>(g_cap_period));
-
-        // The game never raises the timer resolution, so its Sleep(1) frame wait
-        // runs at the ~15.6 ms default quantum and cannot pace anything faster
-        // than ~64 FPS.
-        if (win32::raise_timer_resolution()) {
-            log::get()->trace("FPSUnlockHook: timer resolution raised to 1 ms");
-        } else {
-            log::get()->warn("FPSUnlockHook: failed to raise timer resolution");
-        }
 
         apply_fps_patch(games::rogue::registry().config<Tag>().target.get());
 

--- a/games/rogue/hooks/fps_unlock.cpp
+++ b/games/rogue/hooks/fps_unlock.cpp
@@ -10,6 +10,7 @@
 
 #include "core/mem/write.hpp"
 #include "core/mem/x64.hpp"
+#include "core/win32/timer_resolution.hpp"
 
 #include "games/rogue/registry.hpp"
 #include "games/rogue/structs.hpp"
@@ -20,9 +21,14 @@ namespace hooks {
 
         games::rogue::FrameTiming *g_frame_timing = nullptr;
 
-        constexpr float         k_min_fps       = 1.0F;
-        constexpr std::uint32_t k_mode_fixed    = 0;
-        constexpr std::uint32_t k_mode_averaged = 3;
+        // The vsync-mode deadline period in milliseconds, read by the mulss inside
+        // UpdateFrameTiming. Sole reference in the binary, so it is ours to retune.
+        std::uintptr_t g_cap_period      = 0;
+        float          g_cap_period_orig = 0.0F;
+
+        constexpr float         k_min_fps    = 1.0F;
+        constexpr std::uint32_t k_mode_fixed = 0;
+        constexpr std::uint32_t k_mode_vsync = 2;
 
         void prime_timestamps() {
             LARGE_INTEGER qpc;
@@ -34,17 +40,28 @@ namespace hooks {
         }
 
         void apply_fps_patch(float target) {
-            if (g_frame_timing == nullptr) {
+            if (g_frame_timing == nullptr || g_cap_period == 0) {
                 return;
             }
 
             target = std::max(target, 0.0F);
 
             if (target < k_min_fps) {
-                g_frame_timing->timing_mode = k_mode_averaged;
+                // Vsync mode measures each frame individually and keeps the engine's
+                // own 1/15 s clamp on the delta. Zeroing its period leaves the frame
+                // deadline at "now", so the wait loop never runs.
+                if (!mem::write<float>(g_cap_period, 0.0F)) {
+                    log::get()->error("FPSUnlockHook: failed to zero cap period");
+                    return;
+                }
+                g_frame_timing->timing_mode = k_mode_vsync;
                 prime_timestamps();
-                log::get()->trace("FPSUnlockHook: uncapped (mode=averaged, timestamps primed)");
+                log::get()->trace("FPSUnlockHook: uncapped (mode=vsync, period=0.0)");
             } else {
+                if (!mem::write<float>(g_cap_period, g_cap_period_orig)) {
+                    log::get()->error("FPSUnlockHook: failed to restore cap period");
+                    return;
+                }
                 g_frame_timing->timing_mode = k_mode_fixed;
                 g_frame_timing->fixed_rate  = target;
                 prime_timestamps();
@@ -79,6 +96,21 @@ namespace hooks {
                           ft_ptr,
                           g_frame_timing->timing_mode,
                           g_frame_timing->fixed_rate);
+
+        g_cap_period      = mem::x64::read_rel(addrs.fps_cap_mulss.value() + 4);
+        g_cap_period_orig = mem::read<float>(g_cap_period);
+        log::get()->trace("FPSUnlockHook: cap period at 0x{:X} ({:.6f} ms)",
+                          g_cap_period,
+                          g_cap_period_orig);
+
+        // The game never raises the timer resolution, so its Sleep(1) frame wait
+        // runs at the ~15.6 ms default quantum and cannot pace anything faster
+        // than ~64 FPS.
+        if (win32::raise_timer_resolution()) {
+            log::get()->trace("FPSUnlockHook: timer resolution raised to 1 ms");
+        } else {
+            log::get()->warn("FPSUnlockHook: failed to raise timer resolution");
+        }
 
         apply_fps_patch(games::rogue::registry().config<Tag>().target.get());
 

--- a/include/core/win32/timer_resolution.hpp
+++ b/include/core/win32/timer_resolution.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace win32 {
+    // Raises the process timer resolution to 1 ms so Sleep() stops rounding up to
+    // the ~15.6 ms default quantum. Idempotent: repeated calls raise it once.
+    auto raise_timer_resolution() -> bool;
+
+    // Drops the resolution raised by raise_timer_resolution(). No-op if unraised.
+    void restore_timer_resolution();
+} // namespace win32

--- a/include/games/rogue/game_data.hpp
+++ b/include/games/rogue/game_data.hpp
@@ -43,6 +43,7 @@ namespace games {
             std::optional<std::uintptr_t> lang_setup;
             std::optional<std::uintptr_t> get_language;
             std::optional<std::uintptr_t> fps_timing_ptr;
+            std::optional<std::uintptr_t> fps_cap_mulss;
             std::optional<std::uintptr_t> game_state_global;
             std::optional<std::uintptr_t> loc_init;
             std::optional<std::uintptr_t> mode_get_by_index;
@@ -74,6 +75,7 @@ namespace games {
             {.name="LANG_SETUP",          .field=&ResolvedAddresses::lang_setup,             .offset=0x00,  .bytes="8B CB E8 ? ? ? ? E8 ? ? ? ? 8B C8 E8 ? ? ? ?"},
             {.name="GET_LANGUAGE",        .field=&ResolvedAddresses::get_language,           .offset=0x00,  .bytes="48 83 EC 28 8B 05 ? ? ? ? 83 F8 17 7C"},
             {.name="FPS_TIMING_PTR",      .field=&ResolvedAddresses::fps_timing_ptr,         .offset=0x0C,  .bytes="C3 CC CC CC CC CC CC CC CC CC CC CC 48 8B 0D ? ? ? ? E9"},
+            {.name="FPS_CAP_MULSS",       .field=&ResolvedAddresses::fps_cap_mulss,          .offset=0x15,  .bytes="48 8B 05 ? ? ? ? F3 48 0F 2A C0 48 85 C0 79 04 F3 0F 58 C1 F3 0F 59 05 ? ? ? ? 33 D2 0F 2F C7"},
             {.name="GAME_STATE_GLOBAL",   .field=&ResolvedAddresses::game_state_global,      .offset=0x00,  .bytes="48 8B 05 ? ? ? ? C6 80 C8 02 00 00 00 C3"},
             {.name="LOC_INIT",            .field=&ResolvedAddresses::loc_init,               .offset=0x00,  .bytes="40 53 48 83 EC ? 48 8B D9 48 89 0D"},
             {.name="MODE_GET_BY_INDEX",   .field=&ResolvedAddresses::mode_get_by_index,      .offset=0x00,  .bytes="4C 8B 91 08 0A 00 00 6B D2 1C 66 0F EF C9 66 0F EF C0 49 8B 82 A8 01 00 00"},

--- a/include/games/rogue/hooks/fps_unlock.hpp
+++ b/include/games/rogue/hooks/fps_unlock.hpp
@@ -32,8 +32,9 @@ namespace hooks {
         using hard_deps = dep_list<>;
         using soft_deps = dep_list<games::rogue::GameStateHook>;
 
-        static constexpr auto required_patterns = std::array<PatternField, 1> {
+        static constexpr auto required_patterns = std::array<PatternField, 2> {
             &Addrs::fps_timing_ptr,
+            &Addrs::fps_cap_mulss,
         };
         static constexpr auto optional_patterns = std::array<PatternField, 0> {};
 

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -10,6 +10,7 @@
 #include "core/diagnostics/crash_handler.hpp"
 #include "core/diagnostics/crash_journal.hpp"
 #include "core/vmp/integrity_bypass.hpp"
+#include "core/win32/timer_resolution.hpp"
 
 #include "games/game_init.hpp"
 
@@ -43,6 +44,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID /*unused*/) {
         watcher().reset();
         g_init_thread.reset();
         vmp::uninstall();
+        win32::restore_timer_resolution();
         diagnostics::crash_journal::write_session_clean();
         diagnostics::crash_journal::close();
         diagnostics::uninstall_veh();

--- a/src/win32/timer_resolution.cpp
+++ b/src/win32/timer_resolution.cpp
@@ -1,0 +1,31 @@
+#include "core/win32/timer_resolution.hpp"
+
+#include <atomic>
+
+#include <Windows.h>
+#include <timeapi.h>
+
+namespace win32 {
+    namespace {
+        std::atomic<bool> g_raised {false};
+    } // namespace
+
+    auto raise_timer_resolution() -> bool {
+        bool expected = false;
+        if (!g_raised.compare_exchange_strong(expected, true)) {
+            return true;
+        }
+        if (timeBeginPeriod(1) == TIMERR_NOERROR) {
+            return true;
+        }
+        g_raised.store(false);
+        return false;
+    }
+
+    void restore_timer_resolution() {
+        bool expected = true;
+        if (g_raised.compare_exchange_strong(expected, false)) {
+            timeEndPeriod(1);
+        }
+    }
+} // namespace win32


### PR DESCRIPTION
`timing_mode` 3 does not uncap anything. `UpdateFrameTiming` re-arms the frame deadline for modes 0, 1 and 3, so mode 3 paces each frame to its own 15-frame trailing average and feeds that lagging average back as the frame delta.

Both uncapped and capped now go through mode 2, which keeps the measured delta and the 1/15 s clamp. Its deadline period is a float with a single reference in the binary: `0` leaves the deadline at the current time so the wait loop never runs, `1000/target` paces to the cap. Mode 0 is gone. It stepped the simulation by `1/fixed_rate` regardless of wall time, so any external limiter below the cap slowed the game in proportion.

While a cap is set the plugin raises the timer resolution to 1 ms. The game never calls `timeBeginPeriod`, so `Sleep(1)` rounds up to ~15.6 ms and nothing above ~64 FPS is reachable. Uncapped there is no wait at all, so the resolution is left alone.

Reproduced the slow motion from #9 under Proton with DXVK holding Present at 60, sim time from `FrameTiming.accumulated_ticks` against QPC:

| Build  | Target | Present | Sim speed |
|--------|--------|---------|-----------|
| master | 120    | 60      | 0.50x     |
| master | 0      | 60      | 1.00x     |
| branch | 120    | 60      | 1.00x     |

`FPS_CAP_MULSS` matches `ACC.exe` exactly once. Builds and lint pass.

Refs #9. Fixes the half-speed the reporter saw at 90 and 120 under their 60 ceiling. The ceiling itself is outside the game: `Present` is called with `SyncInterval=0`, the swapchain is a windowed blt-model chain, and with `BorderlessWindow=1` exclusive fullscreen is never entered, so on Windows DWM composes at desktop refresh.
