### PR TITLE
feat(syndicate): add CameraSmoothing hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ ASI plugin framework for Assassin's Creed games that patches game binaries at ru
 
 - **Controller prompt override** — force PlayStation or Xbox button prompts regardless of connected controller
 - **DualShock 4 v2 fix** — recognize DS4v2 (PID 0x09CC) for correct PlayStation prompts
+- **Camera smoothing toggle** — disable the smoothing applied to look input so the camera tracks the mouse directly
 - **Platform specs fix** — stub DxDiag COM initialization to prevent a startup freeze/deadlock
 - **FPS unlock** — remove or adjust the built-in frame rate cap
 - **Resolution fix** — filter non-standard aspect ratio resolutions (e.g., 4096x2160 / 17:9) from the display mode list
@@ -138,6 +139,7 @@ All settings are in `AC.Syndicate.PatchFix.ini`. Changes are picked up automatic
 | Key          | Default       | Values                  | Description |
 |--------------|---------------|-------------------------| ----------- |
 | `PromptType` | `PlayStation` | `Xbox`, `PlayStation`   | Force controller button prompt type. Useful when Steam Input remapping causes wrong prompts. |
+| `DisableCameraSmoothing` | `true` | `true`, `false` | Disable the camera smoothing applied to look input, so the camera follows the mouse directly instead of lerping toward it. |
 
 #### \[FPS\]
 
@@ -161,6 +163,7 @@ Toggle individual hooks. Accepts `true`/`false`, `yes`/`no`, `on`/`off`, `1`/`0`
 | `PlatformSpecsFix` | `true`  | Stub DxDiag COM init to prevent startup freeze |
 | `DS4v2Fix`         | `true`  | DualShock 4 v2 controller recognition |
 | `PromptOverride`   | `true`  | Force controller prompt type |
+| `CameraSmoothing`  | `true`  | Camera smoothing disable |
 | `ResolutionFix`    | `true`  | Filter non-standard aspect ratio resolutions |
 | `FPSUnlock`        | `true`  | FPS cap removal / custom cap |
 | `LanguageUnlock`   | `true`  | Language unlock |
@@ -246,6 +249,24 @@ The engine determines button prompt style through `get_active_device_type`, whic
 
 The patch hooks `get_active_device_type` at its entry point. When a controller is active and the hook is enabled, it replaces the return value with the configured prompt type (2 for Xbox, 5 for PlayStation) and skips the rest of the function. This is hot-reloadable and respects the per-hook toggle.
 
+#### Camera Smoothing
+
+The engine lerps the camera toward its target orientation instead of snapping to it, which reads as mouse smoothing. It already has a flag that bypasses this, checked immediately before the interpolation:
+
+```
+mov  rcx, [r13+0xA20]
+cmp  byte [rcx+0x104], 0
+jnz  skip_smoothing        ; patched to jmp
+...
+movss xmm0, [rbx+0xA0]
+call  <lerp>
+movss [rax+0xA0], xmm0
+```
+
+The patch rewrites the `jnz` opcode (`0x75`) to `jmp` (`0xEB`), keeping the same displacement, so the interpolation is always skipped and the camera target is written straight through. Restoring `0x75` re-enables smoothing, which makes the setting hot-reloadable.
+
+The branch was identified by [@lnx00](https://github.com/lnx00) in [game-patches](https://github.com/lnx00/game-patches/blob/master/x64/acs-patches/src/patches/disable_camera_smoothing.rs).
+
 #### Resolution Fix
 
 The game populates its display mode list by calling `ModeList_InsertSorted` for each resolution the display driver reports. Some monitors report non-standard aspect ratios (e.g., 4096x2160 which reduces to 256:135) that the engine doesn't handle correctly, causing rendering artifacts or broken UI.
@@ -306,6 +327,7 @@ Output: `build/bin/AC.Rogue.PatchFix.asi`, `build/bin/AC.Syndicate.PatchFix.asi`
 
 ## Credits
 
+- [**@lnx00**](https://github.com/lnx00) — [game-patches](https://github.com/lnx00/game-patches), source of the Syndicate camera smoothing branch
 - [**@ThirteenAG**](https://github.com/ThirteenAG) — [Ultimate ASI Loader](https://github.com/ThirteenAG/Ultimate-ASI-Loader), [Hooking.Patterns](https://github.com/ThirteenAG/Hooking.Patterns)
 - [**@cursey**](https://github.com/cursey) — [safetyhook](https://github.com/cursey/safetyhook)
 - [**@metayeti**](https://github.com/metayeti) — [mINI](https://github.com/metayeti/mINI)

--- a/config/AC.Syndicate.PatchFix.ini
+++ b/config/AC.Syndicate.PatchFix.ini
@@ -14,6 +14,12 @@
 ; Type: Xbox, PlayStation
 PromptType=PlayStation
 
+; CameraSmoothing: Disable the camera smoothing the game applies to look
+; input, so the camera follows the mouse directly instead of lerping toward
+; it. Hot-reloadable — unlike the [Hooks] toggle below, which only decides
+; whether the hook installs at startup, this key takes effect immediately.
+DisableCameraSmoothing=true
+
 [Display]
 ; ResolutionFix: Filter non-standard aspect ratio resolutions (e.g.
 ; 4096x2160 / 256:135) from the display mode list. Prevents black bars
@@ -41,6 +47,7 @@ DS4v2Fix=true
 ; Off by default: DS4v2Fix already handles DS4 detection automatically.
 ; Enable to force a specific prompt type when Steam Input remapping interferes.
 PromptOverride=false
+CameraSmoothing=true
 ResolutionFix=true
 FPSUnlock=true
 LanguageUnlock=true

--- a/games/syndicate/hooks/camera_smoothing.cpp
+++ b/games/syndicate/hooks/camera_smoothing.cpp
@@ -1,0 +1,70 @@
+#include "games/syndicate/hooks/camera_smoothing.hpp"
+
+#include <cstdint>
+
+#include "core/logger.hpp" // IWYU pragma: keep
+
+#include "core/mem/write.hpp"
+
+#include "games/syndicate/registry.hpp"
+
+namespace hooks {
+    namespace {
+        using Tag = games::syndicate::CameraSmoothingHook;
+
+        // The game already gates its own camera smoothing behind a flag, then jumps
+        // past the lerp when that flag is set. Forcing the branch to jump always
+        // makes the camera target apply directly on every frame.
+        //
+        // Branch identified by @lnx00 in lnx00/game-patches:
+        // x64/acs-patches/src/patches/disable_camera_smoothing.rs
+        constexpr std::uint8_t k_op_jnz = 0x75;
+        constexpr std::uint8_t k_op_jmp = 0xEB;
+
+        std::uintptr_t g_branch = 0;
+
+        void apply_smoothing_patch(bool disable) {
+            if (g_branch == 0) {
+                return;
+            }
+
+            auto opcode = disable ? k_op_jmp : k_op_jnz;
+            if (!mem::write<std::uint8_t>(g_branch, opcode)) {
+                log::get()->error("Syndicate CameraSmoothingHook: failed to write branch opcode");
+                return;
+            }
+
+            log::get()->trace("Syndicate CameraSmoothingHook: smoothing {}",
+                              disable ? "disabled" : "enabled");
+        }
+    } // namespace
+
+    void HookTraits<Tag>::on_reload(const Config &cfg) {
+        apply_smoothing_patch(cfg.disable.get());
+    }
+
+    auto HookTraits<Tag>::install(const Addrs &addrs) -> bool {
+        log::get()->trace("Syndicate CameraSmoothingHook: installing");
+
+        auto branch_addr = addrs.camera_smoothing_jnz.value();
+
+        // Only the opcode byte is rewritten, so refuse to touch anything that is
+        // not the jnz the signature was written for.
+        auto opcode = mem::read<std::uint8_t>(branch_addr);
+        if (opcode != k_op_jnz) {
+            log::get()->error(
+                "Syndicate CameraSmoothingHook: expected jnz at 0x{:X}, found 0x{:02X}",
+                branch_addr,
+                opcode);
+            return false;
+        }
+
+        g_branch = branch_addr;
+        log::get()->trace("Syndicate CameraSmoothingHook: smoothing branch at 0x{:X}", branch_addr);
+
+        apply_smoothing_patch(games::syndicate::registry().config<Tag>().disable.get());
+
+        log::get()->info("Syndicate CameraSmoothingHook: installed");
+        return true;
+    }
+} // namespace hooks

--- a/include/games/syndicate/game_data.hpp
+++ b/include/games/syndicate/game_data.hpp
@@ -25,6 +25,7 @@ namespace games {
             std::optional<std::uintptr_t> ds4_type_classify;
             std::optional<std::uintptr_t> specs_enumerate_modes;
             std::optional<std::uintptr_t> get_active_device_type;
+            std::optional<std::uintptr_t> camera_smoothing_jnz;
             std::optional<std::uintptr_t> fps_sleep_branch;
             std::optional<std::uintptr_t> fps_frame_time;
         };
@@ -37,6 +38,7 @@ namespace games {
             {.name="DS4_TYPE_CLASSIFY",      .field=&ResolvedAddresses::ds4_type_classify,      .offset=0x00, .bytes="B9 C4 05 00 00 66 3B C1 75 ? C7 83 90 07 00 00 0B 00 00 00"},
             {.name="SPECS_ENUM_MODES",       .field=&ResolvedAddresses::specs_enumerate_modes,  .offset=0x00, .bytes="48 8B C4 55 48 8D 68 ? 48 81 EC ? ? ? ? 48 89 58 ? 48 89 70 ? 48 89 78 ? 4C 89 60 ? 45 33 E4"},
             {.name="GET_ACTIVE_DEVICE_TYPE", .field=&ResolvedAddresses::get_active_device_type, .offset=0x00, .bytes="48 8B 41 ? 48 8B 50 ? 8B 8A ? ? ? ? 48 8B 82"},
+            {.name="CAMERA_SMOOTHING_JNZ",   .field=&ResolvedAddresses::camera_smoothing_jnz,   .offset=0x00, .bytes="75 ? 80 7D ? ? 75 ? 48 8B D9"},
             {.name="FPS_SLEEP_BRANCH",       .field=&ResolvedAddresses::fps_sleep_branch,       .offset=0x0E, .bytes="48 89 43 78 0F 84 ? ? ? ? 48 3B 43 70 73"},
             {.name="FPS_FRAME_TIME",         .field=&ResolvedAddresses::fps_frame_time,         .offset=0x1C, .bytes="48 03 F8 48 8B 05 ? ? ? ? F3 48 0F 2A C0 48 85 C0 79 08 F3 0F 58 05 ? ? ? ? F3 0F 59 05"},
         });

--- a/include/games/syndicate/hooks/camera_smoothing.hpp
+++ b/include/games/syndicate/hooks/camera_smoothing.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+
+#include <array>
+#include <optional>
+#include <string_view>
+#include <tuple>
+
+#include "core/hooks/registry/config_base.hpp"
+#include "core/hooks/registry/dep_list.hpp"
+#include "core/hooks/registry/hook_traits.hpp"
+#include "core/hooks/registry/ini_field.hpp"
+
+#include "games/syndicate/game_data.hpp"
+
+namespace games::syndicate {
+    struct CameraSmoothingHook {};
+} // namespace games::syndicate
+
+namespace hooks {
+    template<>
+    struct HookTraits<games::syndicate::CameraSmoothingHook> {
+        using Addrs        = games::game_data<games::Syndicate>::ResolvedAddresses;
+        using PatternField = std::optional<std::uintptr_t> Addrs::*;
+
+        static constexpr std::string_view name = "CameraSmoothing";
+
+        using hard_deps = dep_list<>;
+        using soft_deps = dep_list<>;
+
+        static constexpr auto required_patterns = std::array<PatternField, 1> {
+            &Addrs::camera_smoothing_jnz,
+        };
+        static constexpr auto optional_patterns = std::array<PatternField, 0> {};
+
+        struct Config : config_base<Config> {
+            ini_field<bool> disable {"Input", "DisableCameraSmoothing", true};
+
+            static constexpr std::size_t field_count = 1;
+            static constexpr auto        field_ptrs  = std::tuple {&Config::disable};
+        };
+
+        static void on_reload(const Config &cfg);
+        static auto install(const Addrs &addrs) -> bool;
+    };
+} // namespace hooks

--- a/include/games/syndicate/registry.hpp
+++ b/include/games/syndicate/registry.hpp
@@ -2,6 +2,7 @@
 
 #include "core/hooks/registry/registry.hpp"
 
+#include "games/syndicate/hooks/camera_smoothing.hpp"
 #include "games/syndicate/hooks/ds4v2_fix.hpp"
 #include "games/syndicate/hooks/fps_unlock.hpp"
 #include "games/syndicate/hooks/language_unlock.hpp"
@@ -14,6 +15,7 @@ namespace games::syndicate {
                                       ResolutionFixHook,
                                       DS4v2FixHook,
                                       PromptOverrideHook,
+                                      CameraSmoothingHook,
                                       FPSUnlockHook,
                                       LanguageUnlockHook>;
 


### PR DESCRIPTION
The camera lerps toward its target orientation instead of snapping to it, which reads as mouse smoothing. The engine already has a flag that bypasses the interpolation, checked by a `jnz` immediately before it:

```
mov  rcx, [r13+0xA20]
cmp  byte [rcx+0x104], 0
jnz  skip_smoothing        ; patched to jmp
...
movss xmm0, [rbx+0xA0]
call  <lerp>
movss [rax+0xA0], xmm0
```

The hook rewrites that opcode from `0x75` to `0xEB`, keeping the displacement, so the smoothing block is always skipped and the target is written straight through. Restoring `0x75` re-enables it, which makes the setting hot-reloadable via `[Input] DisableCameraSmoothing`. `install()` refuses to patch unless the byte actually reads `0x75`, so a signature that drifts on a future game build fails loudly instead of corrupting an instruction.

The signature `75 ? 80 7D ? ? 75 ? 48 8B D9` is unique in the unpacked module.

Branch identified by [@lnx00](https://github.com/lnx00) in [game-patches](https://github.com/lnx00/game-patches/blob/master/x64/acs-patches/src/patches/disable_camera_smoothing.rs); credited in the README.
