### PR TITLE
fix(rogue): show every display mode and stop the settings menu crashing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -67,7 +67,7 @@ IncludeCategories:
     Priority: 30
     SortPriority: 30
   # Other Windows / system headers
-  - Regex: '^<(winternl|DbgHelp|guiddef)\.h>'
+  - Regex: '^<(winternl|DbgHelp|guiddef|dxgi)\.h>'
     Priority: 30
     SortPriority: 31
   # Test frameworks

--- a/config/AC.Rogue.PatchFix.ini
+++ b/config/AC.Rogue.PatchFix.ini
@@ -70,3 +70,6 @@ DisplayDetection=true
 FOVCorrection=true
 FPSUnlock=true
 LanguageUnlock=true
+; Clamps the display mode index the settings menu reads, which the game
+; does not bounds check.
+ModeIndexGuard=true

--- a/config/AC.Rogue.PatchFix.ini
+++ b/config/AC.Rogue.PatchFix.ini
@@ -73,3 +73,6 @@ LanguageUnlock=true
 ; Clamps the display mode index the settings menu reads, which the game
 ; does not bounds check.
 ModeIndexGuard=true
+; Lists every display mode the monitor reports instead of one per
+; resolution at 60 Hz.
+FullModeList=true

--- a/games/rogue/hooks/full_mode_list.cpp
+++ b/games/rogue/hooks/full_mode_list.cpp
@@ -1,0 +1,187 @@
+#include "games/rogue/hooks/full_mode_list.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+
+#include <algorithm>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <dxgi.h>
+
+#include "core/logger.hpp" // IWYU pragma: keep
+
+#include "core/mem/hook.hpp"
+
+namespace hooks {
+    namespace {
+        using Tag = games::rogue::FullModeListHook;
+
+        // Renderer fields the original list builder works on.
+        constexpr std::uintptr_t k_output      = 0x18;
+        constexpr std::uintptr_t k_format      = 0x150;
+        constexpr std::uintptr_t k_mode_vector = 0x1A8;
+        constexpr std::uintptr_t k_mode_cap    = 0x1B0;
+        constexpr std::uintptr_t k_mode_count  = 0x1B2;
+
+        constexpr std::uint32_t k_capacity_mask = 0x3FFF;
+
+        // The engine drops anything smaller than this before the list is built.
+        constexpr std::uint32_t k_min_width  = 800;
+        constexpr std::uint32_t k_min_height = 600;
+
+        // char reserve(vector *self, uint32_t capacity, void *allocator)
+        using ReserveFn = char (*)(void *, std::uint32_t, void *);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wexit-time-destructors"
+#pragma clang diagnostic ignored "-Wglobal-constructors"
+        mem::MidHook g_hook;
+#pragma clang diagnostic pop
+
+        ReserveFn g_reserve        = nullptr;
+        void    **g_allocator_slot = nullptr;
+
+        auto refresh_hz(const DXGI_MODE_DESC &mode) -> std::uint32_t {
+            if (mode.RefreshRate.Denominator == 0) {
+                return 0;
+            }
+            const auto num = static_cast<float>(mode.RefreshRate.Numerator);
+            const auto den = static_cast<float>(mode.RefreshRate.Denominator);
+            return static_cast<std::uint32_t>(std::lround(num / den));
+        }
+
+        // The engine keeps one entry per resolution, preferring whichever mode sits
+        // within 1 Hz of 60, so a 165 Hz panel loses every native-refresh entry and
+        // the saved mode no longer resolves to an index. Fill the list with every
+        // mode the output reports instead, in the order the lookup expects.
+        void rebuild(std::uintptr_t renderer) {
+            *reinterpret_cast<std::uint16_t *>(renderer + k_mode_count) = 0;
+
+            auto *output = *reinterpret_cast<IDXGIOutput **>(renderer + k_output);
+            if (output == nullptr) {
+                return;
+            }
+
+            const auto format = *reinterpret_cast<DXGI_FORMAT *>(renderer + k_format);
+
+            UINT available = 0;
+            if (FAILED(output->GetDisplayModeList(format,
+                                                  DXGI_ENUM_MODES_SCALING,
+                                                  &available,
+                                                  nullptr)) ||
+                available == 0) {
+                log::get()->warn("FullModeList: output reported no modes");
+                return;
+            }
+
+            std::vector<DXGI_MODE_DESC> modes(available);
+            if (FAILED(output->GetDisplayModeList(format,
+                                                  DXGI_ENUM_MODES_SCALING,
+                                                  &available,
+                                                  modes.data()))) {
+                log::get()->error("FullModeList: GetDisplayModeList failed");
+                return;
+            }
+            modes.resize(available);
+
+            std::erase_if(modes, [](const DXGI_MODE_DESC &mode) -> bool {
+                return mode.Width < k_min_width || mode.Height < k_min_height;
+            });
+            if (modes.empty()) {
+                log::get()->warn("FullModeList: every reported mode was below {}x{}",
+                                 k_min_width,
+                                 k_min_height);
+                return;
+            }
+
+            // The index lookup is a binary search over (width, height, refresh).
+            std::ranges::sort(modes, [](const DXGI_MODE_DESC &a, const DXGI_MODE_DESC &b) -> bool {
+                if (a.Width != b.Width) {
+                    return a.Width < b.Width;
+                }
+                if (a.Height != b.Height) {
+                    return a.Height < b.Height;
+                }
+                return refresh_hz(a) < refresh_hz(b);
+            });
+
+            const auto capacity = *reinterpret_cast<std::uint32_t *>(renderer + k_mode_cap) &
+                                  k_capacity_mask;
+            if (modes.size() > capacity) {
+                g_reserve(reinterpret_cast<void *>(renderer + k_mode_vector),
+                          static_cast<std::uint32_t>(modes.size()),
+                          *g_allocator_slot);
+            }
+
+            auto *dst = *reinterpret_cast<DXGI_MODE_DESC **>(renderer + k_mode_vector);
+            if (dst == nullptr) {
+                log::get()->error("FullModeList: mode list allocation failed");
+                return;
+            }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage-in-libc-call"
+            std::memcpy(dst, modes.data(), modes.size() * sizeof(DXGI_MODE_DESC));
+#pragma clang diagnostic pop
+            *reinterpret_cast<std::uint16_t *>(renderer + k_mode_count) =
+                static_cast<std::uint16_t>(modes.size());
+
+            log::get()->info("FullModeList: published {} modes ({}x{} @{}Hz first, {}x{} @{}Hz "
+                             "last)",
+                             modes.size(),
+                             modes.front().Width,
+                             modes.front().Height,
+                             refresh_hz(modes.front()),
+                             modes.back().Width,
+                             modes.back().Height,
+                             refresh_hz(modes.back()));
+        }
+
+        struct BuildModeList {
+            [[maybe_unused]] static constexpr std::string_view name = "FullModeList";
+
+            [[maybe_unused]] static void operator()(mem::Registers &regs) {
+                rebuild(regs.rcx);
+
+                // The mid hook stub resumes with `mov rsp, trampoline_rsp; ret`, so
+                // pointing it at the entry rsp returns to the caller and pops the
+                // return address exactly as the original epilogue would.
+                regs.rax            = 1;
+                regs.trampoline_rsp = regs.rsp;
+            }
+        };
+
+        auto rel32_target(std::uintptr_t operand, std::uintptr_t next_insn) -> std::uintptr_t {
+            const auto rel = *reinterpret_cast<const std::int32_t *>(operand);
+            return static_cast<std::uintptr_t>(static_cast<std::intptr_t>(next_insn) + rel);
+        }
+    } // namespace
+
+    auto HookTraits<Tag>::install(const Addrs &addrs) -> bool {
+        // mov r8, cs:allocator | mov edx, ecx | lea rcx, [r14+1A8h] | call reserve
+        const auto site = addrs.mode_list_reserve_site.value();
+
+        // The allocator global is filled in during engine startup, so keep the slot
+        // and read it when the list is actually rebuilt.
+        g_allocator_slot = reinterpret_cast<void **>(rel32_target(site + 3, site + 7));
+        g_reserve        = reinterpret_cast<ReserveFn>(rel32_target(site + 0x11, site + 0x15));
+        auto address     = addrs.mode_list_build.value();
+
+        auto hook_result = mem::make_hook<BuildModeList>(address);
+        if (!hook_result) {
+            log::get()->error("FullModeList: hook failed: {}", hook_result.error());
+            return false;
+        }
+        g_hook = std::move(*hook_result);
+
+        log::get()->info("FullModeList: installed at 0x{:X} (reserve=0x{:X}, allocator slot "
+                         "0x{:X})",
+                         address,
+                         reinterpret_cast<std::uintptr_t>(g_reserve),
+                         reinterpret_cast<std::uintptr_t>(g_allocator_slot));
+        return true;
+    }
+} // namespace hooks

--- a/games/rogue/hooks/mode_index_guard.cpp
+++ b/games/rogue/hooks/mode_index_guard.cpp
@@ -1,0 +1,91 @@
+#include "games/rogue/hooks/mode_index_guard.hpp"
+
+#include <cstdint>
+
+#include <atomic>
+#include <string_view>
+#include <utility>
+
+#include "core/logger.hpp" // IWYU pragma: keep
+
+#include "core/mem/hook.hpp"
+
+namespace hooks {
+    namespace {
+        using Tag = games::rogue::ModeIndexGuardHook;
+
+        // Display manager -> swapchain owner, then its mode list and entry count.
+        constexpr std::uintptr_t k_display_owner = 0xA08;
+        constexpr std::uintptr_t k_mode_count    = 0x1B2;
+
+        // Stack layout at the entry of the getter: return address, then the fifth
+        // argument (the refresh rate out parameter) in its home slot.
+        constexpr std::uintptr_t k_arg5_slot = 0x28;
+
+        constexpr unsigned k_max_reports = 8;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wexit-time-destructors"
+#pragma clang diagnostic ignored "-Wglobal-constructors"
+        mem::MidHook          g_hook;
+        std::atomic<unsigned> g_reports {0};
+#pragma clang diagnostic pop
+
+        // The getter indexes its mode array with no bounds check, so the -1 the
+        // settings code stores when the saved mode is missing from the list reads
+        // 4 GB past the array and faults. Mirror the clamp the mode setter already
+        // does on the same index.
+        struct ClampModeIndex {
+            [[maybe_unused]] static constexpr std::string_view name = "ModeIndexGuard";
+
+            [[maybe_unused]] static void operator()(mem::Registers &regs) {
+                const auto owner = *reinterpret_cast<std::uintptr_t *>(regs.rcx + k_display_owner);
+                if (owner == 0) {
+                    return;
+                }
+
+                const auto count = *reinterpret_cast<std::uint16_t *>(owner + k_mode_count);
+                const auto index = static_cast<std::uint32_t>(regs.rdx);
+                if (index < count) {
+                    return;
+                }
+
+                const auto reported = g_reports.fetch_add(1, std::memory_order_relaxed);
+                if (reported < k_max_reports) {
+                    log::get()->warn("ModeIndexGuard: mode index {} out of range, list holds {}",
+                                     static_cast<std::int32_t>(index),
+                                     count);
+                }
+
+                if (count != 0) {
+                    regs.rdx = count - 1U;
+                    return;
+                }
+
+                // Nothing to clamp to. Zero the out parameters and return, since the
+                // caller reads them either way.
+                auto *out_refresh = *reinterpret_cast<std::uint32_t **>(regs.rsp + k_arg5_slot);
+                *reinterpret_cast<std::uint32_t *>(regs.r8) = 0;
+                *reinterpret_cast<std::uint32_t *>(regs.r9) = 0;
+                *out_refresh                                = 0;
+
+                regs.rax            = reinterpret_cast<std::uintptr_t>(out_refresh);
+                regs.trampoline_rsp = regs.rsp;
+            }
+        };
+    } // namespace
+
+    auto HookTraits<Tag>::install(const Addrs &addrs) -> bool {
+        auto addr = addrs.mode_get_by_index.value();
+
+        auto hook_result = mem::make_hook<ClampModeIndex>(addr);
+        if (!hook_result) {
+            log::get()->error("ModeIndexGuard: hook failed: {}", hook_result.error());
+            return false;
+        }
+        g_hook = std::move(*hook_result);
+
+        log::get()->info("ModeIndexGuard: installed at 0x{:X}", addr);
+        return true;
+    }
+} // namespace hooks

--- a/include/games/rogue/game_data.hpp
+++ b/include/games/rogue/game_data.hpp
@@ -45,6 +45,7 @@ namespace games {
             std::optional<std::uintptr_t> fps_timing_ptr;
             std::optional<std::uintptr_t> game_state_global;
             std::optional<std::uintptr_t> loc_init;
+            std::optional<std::uintptr_t> mode_get_by_index;
         };
 
         // clang-format off
@@ -67,6 +68,7 @@ namespace games {
             {.name="FPS_TIMING_PTR",      .field=&ResolvedAddresses::fps_timing_ptr,       .offset=0x0C, .bytes="C3 CC CC CC CC CC CC CC CC CC CC CC 48 8B 0D ? ? ? ? E9"},
             {.name="GAME_STATE_GLOBAL",   .field=&ResolvedAddresses::game_state_global,    .offset=0x00, .bytes="48 8B 05 ? ? ? ? C6 80 C8 02 00 00 00 C3"},
             {.name="LOC_INIT",            .field=&ResolvedAddresses::loc_init,             .offset=0x00, .bytes="40 53 48 83 EC ? 48 8B D9 48 89 0D"},
+            {.name="MODE_GET_BY_INDEX",   .field=&ResolvedAddresses::mode_get_by_index,    .offset=0x00, .bytes="4C 8B 91 08 0A 00 00 6B D2 1C 66 0F EF C9 66 0F EF C0 49 8B 82 A8 01 00 00"},
         });
         // clang-format on
     };

--- a/include/games/rogue/game_data.hpp
+++ b/include/games/rogue/game_data.hpp
@@ -46,29 +46,39 @@ namespace games {
             std::optional<std::uintptr_t> game_state_global;
             std::optional<std::uintptr_t> loc_init;
             std::optional<std::uintptr_t> mode_get_by_index;
+            std::optional<std::uintptr_t> mode_list_build;
+            std::optional<std::uintptr_t> mode_list_reserve_site;
         };
+
+        // Builder that fills the display mode list. The reserve site inside it hands
+        // over the vector growth helper and the allocator it is called with.
+        static constexpr std::string_view k_mode_list_build_sig =
+            "48 89 4C 24 08 55 56 57 41 54 48 8D 6C 24 ? 48 81 EC 88 00 00 00 48 8B F1 45 33 "
+            "E4 4C 8D 45 ? 66 44 89 A1 B2 01 00 00";
 
         // clang-format off
         static constexpr auto scan_entries = std::to_array<ScanEntry<ResolvedAddresses>>({
-            {.name="VIEWPORT_RATIO_LOAD", .field=&ResolvedAddresses::viewport_ratio_load,  .offset=0x05, .bytes="0F 28 E8 EB ? F3 0F 10 05 ? ? ? ? F3 0F 5E C1 F3 0F 59 C4"},
-            {.name="VIEWPORT_RATIO_MUL",  .field=&ResolvedAddresses::viewport_ratio_mul,   .offset=0x00, .bytes="F3 0F 59 25 ? ? ? ? EB ? 0F 28 E5"},
-            {.name="SCALING_BRANCH",      .field=&ResolvedAddresses::scaling_branch_start, .offset=0x00, .bytes="45 0F 2F C1 41 0F 28 F0 41 0F 28 F9 76 ? 41 0F 28 F8 F3 0F 59 3D"},
-            {.name="SCALING_BRANCH",      .field=&ResolvedAddresses::scaling_branch_end,   .offset=0x52, .bytes="45 0F 2F C1 41 0F 28 F0 41 0F 28 F9 76 ? 41 0F 28 F8 F3 0F 59 3D"},
-            {.name="DISPLAY_FLAG",        .field=&ResolvedAddresses::display_flag,         .offset=0x00, .bytes="0F 2F C8 73 ? 8B D6 F3 0F 59 15"},
-            {.name="FOV_STORE",           .field=&ResolvedAddresses::fov_store,            .offset=0x05, .bytes="89 43 40 EB 05 F3 0F 11 73 40 48 8D 54 24 40"},
-            {.name="COORD_TRANSFORM",     .field=&ResolvedAddresses::coord_transform,      .offset=0x00, .bytes="0F 28 D0 F3 0F 59 15 ? ? ? ? 0F 2F CA 77"},
-            {.name="SCALING_OFFSETS",     .field=&ResolvedAddresses::scaling_offsets,      .offset=0x00, .bytes="F3 0F 11 4C 24 30 F3 0F 59 05 ? ? ? ? F3 0F 11 44 24 34"},
-            {.name="GAME_UNPAUSE",        .field=&ResolvedAddresses::game_unpause,         .offset=0x00, .bytes="C6 81 C0 02 00 00 00 48 8B 91 90 02 00 00 48 8B D9"},
-            {.name="GAME_PAUSE",          .field=&ResolvedAddresses::game_pause,           .offset=0x11, .bytes="48 C1 E1 20 48 C1 F9 3F 48 23 08 48 39 4A 18 75 08 41 C6 80 C0 02 00 00 01"},
-            {.name="GAME_PAUSE2",         .field=&ResolvedAddresses::game_pause2,          .offset=0x06, .bytes="48 39 46 18 75 ? C6 87 C0 02 00 00 01 48 8B 74 24"},
-            {.name="GET_GAME_ID",         .field=&ResolvedAddresses::get_game_id,          .offset=0x00, .bytes="48 83 EC 28 B9 ? ? ? ? E8 ? ? ? ? 84 C0 74 ? E8 ? ? ? ? 33 C9 84 C0 0F 95 C1 8D 81 ? ? ? ?"},
-            {.name="LANG_BF_WRITE",       .field=&ResolvedAddresses::lang_bf_write,        .offset=0x05, .bytes="0F B6 44 24 ? 89 3D ? ? ? ? 89 1D ? ? ? ? 89 05"},
-            {.name="LANG_SETUP",          .field=&ResolvedAddresses::lang_setup,           .offset=0x00, .bytes="8B CB E8 ? ? ? ? E8 ? ? ? ? 8B C8 E8 ? ? ? ?"},
-            {.name="GET_LANGUAGE",        .field=&ResolvedAddresses::get_language,         .offset=0x00, .bytes="48 83 EC 28 8B 05 ? ? ? ? 83 F8 17 7C"},
-            {.name="FPS_TIMING_PTR",      .field=&ResolvedAddresses::fps_timing_ptr,       .offset=0x0C, .bytes="C3 CC CC CC CC CC CC CC CC CC CC CC 48 8B 0D ? ? ? ? E9"},
-            {.name="GAME_STATE_GLOBAL",   .field=&ResolvedAddresses::game_state_global,    .offset=0x00, .bytes="48 8B 05 ? ? ? ? C6 80 C8 02 00 00 00 C3"},
-            {.name="LOC_INIT",            .field=&ResolvedAddresses::loc_init,             .offset=0x00, .bytes="40 53 48 83 EC ? 48 8B D9 48 89 0D"},
-            {.name="MODE_GET_BY_INDEX",   .field=&ResolvedAddresses::mode_get_by_index,    .offset=0x00, .bytes="4C 8B 91 08 0A 00 00 6B D2 1C 66 0F EF C9 66 0F EF C0 49 8B 82 A8 01 00 00"},
+            {.name="VIEWPORT_RATIO_LOAD", .field=&ResolvedAddresses::viewport_ratio_load,    .offset=0x05,  .bytes="0F 28 E8 EB ? F3 0F 10 05 ? ? ? ? F3 0F 5E C1 F3 0F 59 C4"},
+            {.name="VIEWPORT_RATIO_MUL",  .field=&ResolvedAddresses::viewport_ratio_mul,     .offset=0x00,  .bytes="F3 0F 59 25 ? ? ? ? EB ? 0F 28 E5"},
+            {.name="SCALING_BRANCH",      .field=&ResolvedAddresses::scaling_branch_start,   .offset=0x00,  .bytes="45 0F 2F C1 41 0F 28 F0 41 0F 28 F9 76 ? 41 0F 28 F8 F3 0F 59 3D"},
+            {.name="SCALING_BRANCH",      .field=&ResolvedAddresses::scaling_branch_end,     .offset=0x52,  .bytes="45 0F 2F C1 41 0F 28 F0 41 0F 28 F9 76 ? 41 0F 28 F8 F3 0F 59 3D"},
+            {.name="DISPLAY_FLAG",        .field=&ResolvedAddresses::display_flag,           .offset=0x00,  .bytes="0F 2F C8 73 ? 8B D6 F3 0F 59 15"},
+            {.name="FOV_STORE",           .field=&ResolvedAddresses::fov_store,              .offset=0x05,  .bytes="89 43 40 EB 05 F3 0F 11 73 40 48 8D 54 24 40"},
+            {.name="COORD_TRANSFORM",     .field=&ResolvedAddresses::coord_transform,        .offset=0x00,  .bytes="0F 28 D0 F3 0F 59 15 ? ? ? ? 0F 2F CA 77"},
+            {.name="SCALING_OFFSETS",     .field=&ResolvedAddresses::scaling_offsets,        .offset=0x00,  .bytes="F3 0F 11 4C 24 30 F3 0F 59 05 ? ? ? ? F3 0F 11 44 24 34"},
+            {.name="GAME_UNPAUSE",        .field=&ResolvedAddresses::game_unpause,           .offset=0x00,  .bytes="C6 81 C0 02 00 00 00 48 8B 91 90 02 00 00 48 8B D9"},
+            {.name="GAME_PAUSE",          .field=&ResolvedAddresses::game_pause,             .offset=0x11,  .bytes="48 C1 E1 20 48 C1 F9 3F 48 23 08 48 39 4A 18 75 08 41 C6 80 C0 02 00 00 01"},
+            {.name="GAME_PAUSE2",         .field=&ResolvedAddresses::game_pause2,            .offset=0x06,  .bytes="48 39 46 18 75 ? C6 87 C0 02 00 00 01 48 8B 74 24"},
+            {.name="GET_GAME_ID",         .field=&ResolvedAddresses::get_game_id,            .offset=0x00,  .bytes="48 83 EC 28 B9 ? ? ? ? E8 ? ? ? ? 84 C0 74 ? E8 ? ? ? ? 33 C9 84 C0 0F 95 C1 8D 81 ? ? ? ?"},
+            {.name="LANG_BF_WRITE",       .field=&ResolvedAddresses::lang_bf_write,          .offset=0x05,  .bytes="0F B6 44 24 ? 89 3D ? ? ? ? 89 1D ? ? ? ? 89 05"},
+            {.name="LANG_SETUP",          .field=&ResolvedAddresses::lang_setup,             .offset=0x00,  .bytes="8B CB E8 ? ? ? ? E8 ? ? ? ? 8B C8 E8 ? ? ? ?"},
+            {.name="GET_LANGUAGE",        .field=&ResolvedAddresses::get_language,           .offset=0x00,  .bytes="48 83 EC 28 8B 05 ? ? ? ? 83 F8 17 7C"},
+            {.name="FPS_TIMING_PTR",      .field=&ResolvedAddresses::fps_timing_ptr,         .offset=0x0C,  .bytes="C3 CC CC CC CC CC CC CC CC CC CC CC 48 8B 0D ? ? ? ? E9"},
+            {.name="GAME_STATE_GLOBAL",   .field=&ResolvedAddresses::game_state_global,      .offset=0x00,  .bytes="48 8B 05 ? ? ? ? C6 80 C8 02 00 00 00 C3"},
+            {.name="LOC_INIT",            .field=&ResolvedAddresses::loc_init,               .offset=0x00,  .bytes="40 53 48 83 EC ? 48 8B D9 48 89 0D"},
+            {.name="MODE_GET_BY_INDEX",   .field=&ResolvedAddresses::mode_get_by_index,      .offset=0x00,  .bytes="4C 8B 91 08 0A 00 00 6B D2 1C 66 0F EF C9 66 0F EF C0 49 8B 82 A8 01 00 00"},
+            {.name="MODE_LIST_BUILD",     .field=&ResolvedAddresses::mode_list_build,        .offset=0x000, .bytes=k_mode_list_build_sig},
+            {.name="MODE_LIST_RESERVE",   .field=&ResolvedAddresses::mode_list_reserve_site, .offset=0x304, .bytes=k_mode_list_build_sig},
         });
         // clang-format on
     };

--- a/include/games/rogue/hooks/full_mode_list.hpp
+++ b/include/games/rogue/hooks/full_mode_list.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+
+#include <array>
+#include <optional>
+#include <string_view>
+
+#include "core/hooks/registry/config_base.hpp"
+#include "core/hooks/registry/dep_list.hpp"
+#include "core/hooks/registry/hook_traits.hpp"
+
+#include "games/rogue/game_data.hpp"
+
+namespace games::rogue {
+    struct FullModeListHook {};
+} // namespace games::rogue
+
+namespace hooks {
+    template<>
+    struct HookTraits<games::rogue::FullModeListHook> {
+        using Addrs        = games::game_data<games::Rogue>::ResolvedAddresses;
+        using PatternField = std::optional<std::uintptr_t> Addrs::*;
+
+        static constexpr std::string_view name = "FullModeList";
+
+        using hard_deps = dep_list<>;
+        using soft_deps = dep_list<>;
+
+        static constexpr auto required_patterns = std::array<PatternField, 2> {
+            &Addrs::mode_list_build,
+            &Addrs::mode_list_reserve_site,
+        };
+        static constexpr auto optional_patterns = std::array<PatternField, 0> {};
+
+        using Config = empty_config;
+
+        static auto install(const Addrs &addrs) -> bool;
+    };
+} // namespace hooks

--- a/include/games/rogue/hooks/mode_index_guard.hpp
+++ b/include/games/rogue/hooks/mode_index_guard.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstdint>
+
+#include <array>
+#include <optional>
+#include <string_view>
+
+#include "core/hooks/registry/config_base.hpp"
+#include "core/hooks/registry/dep_list.hpp"
+#include "core/hooks/registry/hook_traits.hpp"
+
+#include "games/rogue/game_data.hpp"
+
+namespace games::rogue {
+    struct ModeIndexGuardHook {};
+} // namespace games::rogue
+
+namespace hooks {
+    template<>
+    struct HookTraits<games::rogue::ModeIndexGuardHook> {
+        using Addrs        = games::game_data<games::Rogue>::ResolvedAddresses;
+        using PatternField = std::optional<std::uintptr_t> Addrs::*;
+
+        static constexpr std::string_view name = "ModeIndexGuard";
+
+        using hard_deps = dep_list<>;
+        using soft_deps = dep_list<>;
+
+        static constexpr auto required_patterns = std::array<PatternField, 1> {
+            &Addrs::mode_get_by_index,
+        };
+        static constexpr auto optional_patterns = std::array<PatternField, 0> {};
+
+        using Config = empty_config;
+
+        static auto install(const Addrs &addrs) -> bool;
+    };
+} // namespace hooks

--- a/include/games/rogue/registry.hpp
+++ b/include/games/rogue/registry.hpp
@@ -7,6 +7,7 @@
 #include "games/rogue/hooks/fps_unlock.hpp"
 #include "games/rogue/hooks/game_state.hpp"
 #include "games/rogue/hooks/language_unlock.hpp"
+#include "games/rogue/hooks/mode_index_guard.hpp"
 #include "games/rogue/hooks/viewport_fitting.hpp"
 #include "games/rogue/hooks/viewport_scaling.hpp"
 
@@ -17,7 +18,8 @@ namespace games::rogue {
                                       ViewportScalingHook,
                                       FOVCorrectionHook,
                                       FPSUnlockHook,
-                                      LanguageUnlockHook>;
+                                      LanguageUnlockHook,
+                                      ModeIndexGuardHook>;
 
     using RogueRegistry = hooks::Registry<AllHooks>;
 

--- a/include/games/rogue/registry.hpp
+++ b/include/games/rogue/registry.hpp
@@ -5,6 +5,7 @@
 #include "games/rogue/hooks/display_detection.hpp"
 #include "games/rogue/hooks/fov_correction.hpp"
 #include "games/rogue/hooks/fps_unlock.hpp"
+#include "games/rogue/hooks/full_mode_list.hpp"
 #include "games/rogue/hooks/game_state.hpp"
 #include "games/rogue/hooks/language_unlock.hpp"
 #include "games/rogue/hooks/mode_index_guard.hpp"
@@ -19,7 +20,8 @@ namespace games::rogue {
                                       FOVCorrectionHook,
                                       FPSUnlockHook,
                                       LanguageUnlockHook,
-                                      ModeIndexGuardHook>;
+                                      ModeIndexGuardHook,
+                                      FullModeListHook>;
 
     using RogueRegistry = hooks::Registry<AllHooks>;
 

--- a/src/diagnostics/crash_handler.cpp
+++ b/src/diagnostics/crash_handler.cpp
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include <atomic>
+
 #include <Windows.h>
 
 #include "core/diagnostics/address_registry.hpp"
@@ -10,6 +12,8 @@
 
 namespace diagnostics {
     namespace {
+        constexpr unsigned k_max_foreign_faults = 8;
+
         void *g_veh_handle = nullptr;
 
         auto NTAPI veh_handler(EXCEPTION_POINTERS *ep) -> LONG {
@@ -33,6 +37,14 @@ namespace diagnostics {
                 log_crash_report_lightweight(ep);
                 log_patch_attribution(ep);
                 return EXCEPTION_CONTINUE_SEARCH;
+            }
+
+            // Faults elsewhere in the process are not ours, but they are the only
+            // record of a crash the game itself leaves behind. Log a bounded number
+            // of them so an unattributed crash still names a module and offset.
+            static std::atomic<unsigned> foreign_faults {0};
+            if (foreign_faults.fetch_add(1, std::memory_order_relaxed) < k_max_foreign_faults) {
+                log_crash_report_lightweight(ep);
             }
 
             return EXCEPTION_CONTINUE_SEARCH;


### PR DESCRIPTION
Two Rogue display bugs with a shared root cause, plus the diagnostics change that located them.

## The bug

`sub_1406F0880` builds the resolution list from `IDXGIOutput::GetDisplayModeList`, then keeps at most one entry per resolution, preferring whichever mode sits within 1 Hz of 60. On a high refresh rate display that drops every native-refresh entry, so the saved mode no longer resolves to an index. `sub_14064FB90` stores -1 for it, the menu copies that into its own state, and `sub_1406D8C20` indexes its mode array with no bounds check:

```
0x1406d8c27  imul edx, 1Ch        ; index * sizeof(DXGI_MODE_DESC)
0x1406d8c32  mov  rax, [r10+1A8h] ; mode array
0x1406d8c39  mov  ecx, [rdx+rax]  ; -1 reads ~4 GB past the array
```

Symptoms: the resolution selector shows `undefined`, the game rewrites `RefreshRate` back to 60 on every save, and any settings interaction that refreshes the apply button (switching away from fullscreen, for one) crashes at `ACC.exe+0x6D8C39`.

## Changes

- `FullModeList` replaces the list builder. Same output, same format, same `DXGI_ENUM_MODES_SCALING` flag and the engine's own 800x600 floor, but every mode is kept, sorted by (width, height, refresh) as the binary search in `sub_1406E08F0` expects. The list grows through the game's own vector helper, resolved by decoding the call at the reserve site.
- `ModeIndexGuard` clamps the index the getter is called with, mirroring the clamp the mode setter already does, and returns zeroed outputs when the list is empty. It also covers a stale index left in an existing ini.
- The VEH previously logged only faults whose RIP landed in the plugin or in a registered patch, so a crash anywhere else left no record. It now logs a bounded number of foreign faults as well, which is what produced the faulting address above.

Both hooks are toggleable in `[Hooks]`.

## Testing

Verified in game on a high refresh rate display. Before: selector showed `undefined`, ini reset to `RefreshRate=60`, crash on leaving fullscreen with no crash record anywhere. After: every mode listed at both its 60 Hz and native-refresh variants, native refresh persisted across saves, no fault logged, `ModeIndexGuard` silent. The published count matches a standalone probe calling `GetDisplayModeList` with the same arguments.
